### PR TITLE
Rename Bella Keys references to Bella Assist in project documentation

### DIFF
--- a/keys-wiki-site/docs/projects/bella-assist/_category_.json
+++ b/keys-wiki-site/docs/projects/bella-assist/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Bella Keys",
+    "label": "Bella Assist",
     "position": 1,
     "link": {
         "type": "doc",

--- a/keys-wiki-site/docs/projects/bella-assist/bella-chat.md
+++ b/keys-wiki-site/docs/projects/bella-assist/bella-chat.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 # Bella Chat Service
 
-The Bella Chat Service is the AI orchestration engine for Bella Keys. It routes user queries to the right tool — financial data via MCP, knowledge search via RAG, or a direct LLM response — and streams the result back token-by-token over SSE.
+The Bella Chat Service is the AI orchestration engine for Bella Assist. It routes user queries to the right tool — financial data via MCP, knowledge search via RAG, or a direct LLM response — and streams the result back token-by-token over SSE.
 
 ---
 

--- a/keys-wiki-site/docs/projects/bella-assist/index.md
+++ b/keys-wiki-site/docs/projects/bella-assist/index.md
@@ -2,24 +2,24 @@
 sidebar_level: 2
 sidebar_label: 'Overview'
 sidebar_position: 1
-description: 'Bella Keys Project Overview'
+description: 'Bella Assist Project Overview'
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CenteredIntro from '@site/src/components/core/CenteredIntro';
 
-# Bella Keys
+# Bella Assist
 
 <CenteredIntro>
-Bella Keys is a privacy-first desktop application combining a personal AI assistant with multi-period expense and budget tracking. Built on LangGraph, FastAPI, React, Electron, and the Model Context Protocol.
+Bella Assist is a privacy-first desktop application combining a personal AI assistant with multi-period expense and budget tracking. Built on LangGraph, FastAPI, React, Electron, and the Model Context Protocol.
 </CenteredIntro>
 
 ---
 
 ## Deployment Architecture
 
-Bella Keys uses an inside-out architecture: application logic runs in Docker containers while all user data (PostgreSQL, Qdrant, Ollama models) stays on the host machine. The React UI is served by nginx in web mode and connects directly to services in Electron mode.
+Bella Assist uses an inside-out architecture: application logic runs in Docker containers while all user data (PostgreSQL, Qdrant, Ollama models) stays on the host machine. The React UI is served by nginx in web mode and connects directly to services in Electron mode.
 
 ```mermaid
 graph TD

--- a/keys-wiki-site/docs/projects/home.md
+++ b/keys-wiki-site/docs/projects/home.md
@@ -19,7 +19,7 @@ A curated showcase of personal engineering projects spanning AI systems, backend
 <div style={{ marginTop: '2.5rem', marginBottom: '1.5rem' }}>
   <FeatureCard
     href="/keys-personal-wiki/docs/projects/bella-assist/"
-    title="Bella Keys &mdash; Personal AI Assistant"
+    title="Bella Assist &mdash; Personal AI Assistant"
     badge="Featured App"
     tags={['Electron', 'LangGraph', 'FastAPI', 'React']}
     description="A privacy-first desktop application combining a personal AI assistant with multi-period expense and budget tracking. Built on LangGraph, FastAPI, React, Electron, and the Model Context Protocol."


### PR DESCRIPTION
This pull request updates the documentation references for the "Bella" application suite. The root application name is updated from "Bella Keys" to "Bella Assist" across the project wiki.

### Changes:
- Updated the Docusaurus category label in `_category_.json` from "Bella Keys" to "Bella Assist".
- Updated project titles and descriptions in `docs/projects/bella-assist/index.md`.
- Renamed references in `docs/projects/bella-assist/bella-chat.md` where the orchestrator agent was described as being built for Bella Keys.
- Changed the featured app title in the project gallery (`docs/projects/home.md`) to "Bella Assist — Personal AI Assistant".
